### PR TITLE
Fixed elixir 1.4 warnings

### DIFF
--- a/lib/alexa/skill.ex
+++ b/lib/alexa/skill.ex
@@ -26,9 +26,9 @@ defmodule Alexa.Skill do
         # TODO: ultimately each alexa session should spawn it's own process and the request
         # TODO: should be delegated to the correct process for handling.
         case type(request) do
-          "LaunchRequest" -> handle_launch(request, empty_response)
-          "IntentRequest" -> handle_intent(intent_name(request), request, empty_response)
-          "SessionEndedRequest" -> handle_session_ended(request, empty_response)
+          "LaunchRequest" -> handle_launch(request, empty_response())
+          "IntentRequest" -> handle_intent(intent_name(request), request, empty_response())
+          "SessionEndedRequest" -> handle_session_ended(request, empty_response())
         end
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,8 +8,8 @@ defmodule Alexa.Mixfile do
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
      description: "Framework for implementing an Amazon Alexa Skill.",
-     package: package,
-     deps: deps]
+     package: package(),
+     deps: deps()]
   end
 
   def package do


### PR DESCRIPTION
Elixir 1.4 expects functions to be expanded with parenthesis. Otherwise it will issue a warning.

**Example**

```elixir
handle_launch(request, empty_response)
```

should be

```elixir
handle_launch(request, empty_response())
```