### PR TITLE
Add flexibility to poison dependency versioning

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -37,6 +37,6 @@ defmodule Alexa.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:poison, "~> 2.0"}]
+    [{:poison, ">= 2.0.0 or < 3.1.0"}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,1 +1,1 @@
-%{"poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []}}
+%{"poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []}}


### PR DESCRIPTION
Added support for using `3.0.x` versions of `poison`. I can add more flexibility and allow `3.x` versions if you'd like.