### PR TITLE
Call copy_attributes for every request.

### DIFF
--- a/lib/alexa/skill.ex
+++ b/lib/alexa/skill.ex
@@ -22,13 +22,14 @@ defmodule Alexa.Skill do
       def handle_request(request) do
         Logger.debug("### Request ###")
         Logger.debug("#{inspect request}")
+        response = copy_attributes(empty_response(), request)
         # TODO: this is not using the skill process yet, it's just calling the handler directly.
         # TODO: ultimately each alexa session should spawn it's own process and the request
         # TODO: should be delegated to the correct process for handling.
         case type(request) do
-          "LaunchRequest" -> handle_launch(request, empty_response())
-          "IntentRequest" -> handle_intent(intent_name(request), request, empty_response())
-          "SessionEndedRequest" -> handle_session_ended(request, empty_response())
+          "LaunchRequest" -> handle_launch(request, response)
+          "IntentRequest" -> handle_intent(intent_name(request), request, response)
+          "SessionEndedRequest" -> handle_session_ended(request, response)
         end
       end
 

--- a/test/alexa/skill_test.exs
+++ b/test/alexa/skill_test.exs
@@ -1,6 +1,6 @@
 defmodule Alexa.SkillTest do
   use ExUnit.Case
-  alias Alexa.{Request, Response, RequestElement}
+  alias Alexa.{Request, Response, RequestElement, Session}
 
   test "handle_request - LaunchRequest - default response" do
     request = %Request{ request: %RequestElement{ type: "LaunchRequest" } }
@@ -14,6 +14,13 @@ defmodule Alexa.SkillTest do
     response = Alexa.handle_request(request)
     assert "Sorry, I don't know how to answer that." = Response.say(response)
     assert false == Response.should_end_session(response)
+  end
+
+  test "handle_intent - IntentRequest - session attributes are copied to response" do
+    request = %Request{ request: %RequestElement{ type: "IntentRequest" },
+                        session: %Session {attributes: %{"one": "value"}}}
+    response = Alexa.handle_request(request)
+    assert "value" == Response.attribute(response,:one)
   end
 
   test "handle_session_ended - SessionEndedRequest - default response" do


### PR DESCRIPTION
This change makes it simpler to preserve the session through every request, even requests which  do not use it. I found it surprising my session value was getting lost on requests that didn't touch the session. In a stateful skill with a lot of handler methods it would be easy to make this mistake and maybe hard to find that mistake if intents were sometimes called in a surprising order.  

This does impose a small cost in the handler for every single request though, and not every skill uses session. Thoughts?

