### PR TITLE
Add Echo show support

### DIFF
--- a/lib/alexa/card.ex
+++ b/lib/alexa/card.ex
@@ -1,8 +1,11 @@
 defmodule Alexa.Card do
-  alias Alexa.Card
-  defstruct [type: "Simple", title: nil, content: nil]
+  defstruct [type: "Simple", title: nil, content: nil, text: nil, image: nil]
 
   def new(type, title, content) do
-    %Card{type: type, title: title, content: content}
+    %__MODULE__{type: type, title: title, content: content}
+  end
+
+  def new(type, title, content, text, image) do
+    %__MODULE__{type: type, title: title, content: content, text: text, image: image}
   end
 end

--- a/lib/alexa/directive.ex
+++ b/lib/alexa/directive.ex
@@ -1,0 +1,11 @@
+defmodule Alexa.Directive do
+  defstruct [type: "Display.RenderTemplate", template: %{}]
+
+  def new(type, %{} = template) do
+    %__MODULE__{type: type, template: template}
+  end
+
+  def from_params(params) do
+    Poison.decode!(Poison.encode!(params), as: %__MODULE__{})
+  end
+end

--- a/lib/alexa/request.ex
+++ b/lib/alexa/request.ex
@@ -46,6 +46,10 @@ defmodule Alexa.Request do
     request.request.type
   end
 
+  def token(request) do
+    request.request.token
+  end
+
   def slots(request) do
     Map.get(request.request.intent, :slots) || %{}
   end

--- a/lib/alexa/request_element.ex
+++ b/lib/alexa/request_element.ex
@@ -1,3 +1,3 @@
 defmodule Alexa.RequestElement do
-  defstruct [intent: %Alexa.Intent{}, type: nil, requestId: nil]
+  defstruct [intent: %Alexa.Intent{}, type: nil, requestId: nil, token: nil]
 end

--- a/lib/alexa/response.ex
+++ b/lib/alexa/response.ex
@@ -1,5 +1,5 @@
 defmodule Alexa.Response do
-  alias Alexa.{Request, ResponseElement, OutputSpeech, Reprompt, Card}
+  alias Alexa.{Request, ResponseElement, OutputSpeech, Reprompt, Card, Directive}
 
   defstruct [version: "1.0", sessionAttributes: %{}, response: %ResponseElement{}]
 
@@ -79,5 +79,14 @@ defmodule Alexa.Response do
 
   def card(response) do
     response.response.card
+  end
+
+  def directives(response) do
+    response.response.directives
+  end
+
+  def add_directive(response, %{} = directive) do
+    directive = Directive.from_params(directive)
+    %{ response | response: %{response.response | directives: [directive | response.response.directives]} }
   end
 end

--- a/lib/alexa/response.ex
+++ b/lib/alexa/response.ex
@@ -72,8 +72,8 @@ defmodule Alexa.Response do
     attributes(response, Request.attributes(request))
   end
 
-  def card(response, type, title, content) do
-    card = Card.new(type, title, content)
+  def card(response, type, title, content, text \\ nil, image \\nil) do
+    card = Card.new(type, title, content, text, image)
     %{ response | response: %{response.response | card: card} }
   end
 

--- a/lib/alexa/response_element.ex
+++ b/lib/alexa/response_element.ex
@@ -1,6 +1,6 @@
 defmodule Alexa.ResponseElement do
   alias Alexa.{OutputSpeech, Card, Reprompt}
-  defstruct [outputSpeech: %OutputSpeech{}, card: %Card{}, reprompt: %Reprompt{}, shouldEndSession: true]
+  defstruct [outputSpeech: %OutputSpeech{}, card: %Card{}, reprompt: %Reprompt{}, shouldEndSession: true, directives: []]
 
   def empty_response() do
     %Alexa.ResponseElement{outputSpeech: %OutputSpeech{}, card: nil, reprompt: nil, shouldEndSession: true}

--- a/lib/alexa/skill.ex
+++ b/lib/alexa/skill.ex
@@ -29,6 +29,7 @@ defmodule Alexa.Skill do
         case type(request) do
           "LaunchRequest" -> handle_launch(request, response)
           "IntentRequest" -> handle_intent(intent_name(request), request, response)
+          "Display.ElementSelected" -> handle_display_element_selected(request, response)
           "SessionEndedRequest" -> handle_session_ended(request, response)
         end
       end
@@ -42,6 +43,12 @@ defmodule Alexa.Skill do
       def handle_intent(_, _, response) do
         response
         |> say("Sorry, I don't know how to answer that.")
+        |> should_end_session(false)
+      end
+
+      def handle_display_element_selected(_, response) do
+        response
+        |> say("Sorry, no action has been set up.")
         |> should_end_session(false)
       end
 
@@ -63,7 +70,7 @@ defmodule Alexa.Skill do
         {:noreply, nil, state}
       end
 
-      defoverridable [handle_launch: 2, handle_intent: 3, handle_session_ended: 2]
+      defoverridable [handle_launch: 2, handle_intent: 3, handle_session_ended: 2, handle_display_element_selected: 2]
     end
   end
 

--- a/test/alexa/request_test.exs
+++ b/test/alexa/request_test.exs
@@ -35,6 +35,12 @@ defmodule Alexa.RequestTest do
     assert "SampleName" = intent_name
   end
 
+  test "token" do
+    request = %Request{ request: %RequestElement{ token: "abc123"} }
+    expected_value = Request.token(request)
+    assert "abc123" = expected_value
+  end
+
   test "slots" do
     slots = %{ "testKey" => %{ "name" => "testKey", "value" => "testValue" } }
     request = %Request{ request: %RequestElement{ intent: %Intent{ slots: slots } } }

--- a/test/alexa/response_test.exs
+++ b/test/alexa/response_test.exs
@@ -1,6 +1,6 @@
 defmodule Alexa.ResponseTest do
   use ExUnit.Case
-  alias Alexa.{Request, Response, ResponseElement, OutputSpeech, Reprompt}
+  alias Alexa.{Request, Response, ResponseElement, OutputSpeech, Reprompt, Directive}
 
   test "say/2" do
     response = %Response{}
@@ -132,5 +132,36 @@ defmodule Alexa.ResponseTest do
     response = Response.empty_response
       |> Response.card("LinkAccount", "Link Account", "You can link your account here.")
     assert %Alexa.Card{type: "LinkAccount", title: "Link Account", content: "You can link your account here."} = Response.card(response)
+  end
+
+  test "directives/1" do
+    directive_1 = %Directive{type: "Display.RenderTemplate", template: %{"title" => "a title 1"}}
+    directive_2 = %Directive{type: "Display.RenderTemplate", template: %{"title" => "a title 2"}}
+    response = %Response{
+      response: %ResponseElement{
+        directives: [directive_2, directive_1]
+      }
+    }
+    assert [
+      %Directive{type: "Display.RenderTemplate", template: %{"title" => "a title 2"}},
+      %Directive{type: "Display.RenderTemplate", template: %{"title" => "a title 1"}}
+    ] = Response.directives(response)
+  end
+
+  test "add_directive/2" do
+    directive_params = %{
+      type: "Display.RenderTemplate",
+      template: %{
+        title: "a title 1"
+      }
+    }
+    directive_params_2 = put_in(directive_params, [:template, :title], "a title 2")
+    response = Response.empty_response
+      |> Response.add_directive(directive_params)
+      |> Response.add_directive(directive_params_2)
+    assert [
+      %Directive{type: "Display.RenderTemplate", template: %{"title" => "a title 2"}},
+      %Directive{type: "Display.RenderTemplate", template: %{"title" => "a title 1"}}
+    ] = Response.directives(response)
   end
 end

--- a/test/alexa/response_test.exs
+++ b/test/alexa/response_test.exs
@@ -128,10 +128,26 @@ defmodule Alexa.ResponseTest do
     assert Response.attributes(response) == attributes
   end
 
-  test "card/4" do
+  test "card/6" do
     response = Response.empty_response
       |> Response.card("LinkAccount", "Link Account", "You can link your account here.")
     assert %Alexa.Card{type: "LinkAccount", title: "Link Account", content: "You can link your account here."} = Response.card(response)
+  end
+
+  test "card/6 with text and image" do
+    images = %{
+      "smallImageUrl": "https://example.com/sm_image.jpg",
+      "largeImageUrl": "https://example.com/lg_image.jpg"
+    }
+    response = Response.empty_response
+      |> Response.card("LinkAccount", "Link Account", "You can link your account here.", "Linking text.", images)
+    assert %Alexa.Card{
+      type: "LinkAccount",
+      title: "Link Account",
+      content: "You can link your account here.",
+      text: "Linking text.",
+      image: images
+    } = Response.card(response)
   end
 
   test "directives/1" do

--- a/test/alexa/skill_test.exs
+++ b/test/alexa/skill_test.exs
@@ -23,6 +23,20 @@ defmodule Alexa.SkillTest do
     assert "value" == Response.attribute(response,:one)
   end
 
+  test "handle_intent - Display.ElementSelected - default response" do
+    request = %Request{ request: %RequestElement{ type: "Display.ElementSelected" } }
+    response = Alexa.handle_request(request)
+    assert "Sorry, no action has been set up." = Response.say(response)
+    assert false == Response.should_end_session(response)
+  end
+
+  test "handle_intent - Display.ElementSelected - session attributes are copied to response" do
+    request = %Request{ request: %RequestElement{ type: "Display.ElementSelected" },
+                        session: %Session {attributes: %{"one": "value"}}}
+    response = Alexa.handle_request(request)
+    assert "value" == Response.attribute(response,:one)
+  end
+
   test "handle_session_ended - SessionEndedRequest - default response" do
     request = %Request{ request: %RequestElement{ type: "SessionEndedRequest" } }
     response = Alexa.handle_request(request)


### PR DESCRIPTION
This PR adds the ability to build directives for echo show displays and allows the library to receive click events from the show.

It also adds images to response cards.