### PR TITLE
Add link to Phoenix boilerplate project

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,7 @@ Here's an example plug implementation:
         conn
       end
     end
+
+Here's an example Phoenix Boilerplate project for bootstrapping your Alexa skill:
+[SDITools/alexa_hello_world](https://github.com/SDITools/alexa_hello_world)
+


### PR DESCRIPTION
Just adding a link to the README to a Phoenix example project using this library.